### PR TITLE
Fix AudioParse and AudioTransfer.

### DIFF
--- a/OfflineAudioProcessingSystem/Common/LocalCommon.cs
+++ b/OfflineAudioProcessingSystem/Common/LocalCommon.cs
@@ -20,12 +20,12 @@ namespace OfflineAudioProcessingSystem
         {
             RunFile.Run(SoxPath, arguments, false, "");
         }
-        public static void CutAudio(string inputAudioPath, object startTime, object duration, string outputAudioPath)
+        public static void CutAudioWithSox(string inputAudioPath, object startTime, object duration, string outputAudioPath)
         {
             string arguments = $"{inputAudioPath} {outputAudioPath} trim {startTime} {duration}";
             RunSox(arguments);
         }
-        public static void MergeAudio(IEnumerable<string> inputAudioList, string outputAudioPath, string listPath)
+        public static void MergeAudioWithFfmpeg(IEnumerable<string> inputAudioList, string outputAudioPath, string listPath)
         {
             var list = inputAudioList.Select(x => $"file '{x}'");
             File.WriteAllLines(listPath, list);
@@ -34,10 +34,16 @@ namespace OfflineAudioProcessingSystem
             RunFfmpeg(arguments);
         }
 
-        public static void SetAudio(string inputAudioPath, int sampleRate, int channelNumber , string outputAudioPath)
+        public static void SetAudioWithFfmpeg(string inputAudioPath, int sampleRate, int channelNumber , string outputAudioPath)
         {
             string arguments = $"-i {inputAudioPath} -ar {sampleRate} -ac {channelNumber} {outputAudioPath}";
             RunFfmpeg(arguments);
+        }
+
+        public static void SetAudioWithSox(string inputAudioPath, int sampleRate, int channelNumber, string outputAudioPath)
+        {
+            string arguments = $"{inputAudioPath} -r {sampleRate} -c {channelNumber} {outputAudioPath}";
+            RunSox(arguments);
         }
     }
 }

--- a/OfflineAudioProcessingSystem/Features/AudioTransfer/AudioTransfer.cs
+++ b/OfflineAudioProcessingSystem/Features/AudioTransfer/AudioTransfer.cs
@@ -11,7 +11,6 @@ namespace OfflineAudioProcessingSystem.AudioTransfer
     class AudioTransfer : Feature
     {
         ConfigAudioTransfer Cfg = new ConfigAudioTransfer();
-
         public override string GetFeatureName()
         {
             return "AudioTransfer";
@@ -24,20 +23,20 @@ namespace OfflineAudioProcessingSystem.AudioTransfer
 
         protected override void Run()
         {
+            var aft = new AudioFolderTransfer(Cfg.ReportPath, Cfg.ExistringFileListPath, Cfg.ErrorPath)
+            {
+                SampleRate = Cfg.SampleRate,
+                NumChannels = Cfg.NumChannels,
+                MaxParallel = 5
+            };
             if (Directory.Exists(Cfg.InputPath))
             {
-                var aft = new AudioFolderTransfer(Cfg.ReportPath, Cfg.ExistringFileListPath, Cfg.ErrorPath)
-                {
-                    SampleRate = Cfg.SampleRate,
-                    NumChannels = Cfg.NumChannels,
-                    MaxParallel = 5
-                };
 
                 aft.Run(Cfg.InputPath, Cfg.OutputPath);
             }
             else if (File.Exists(Cfg.InputPath))
             {
-                LocalCommon.SetAudio(Cfg.InputPath, Cfg.SampleRate, Cfg.NumChannels, Cfg.OutputPath);
+                aft.ConvertToWave(Cfg.InputPath, Cfg.OutputPath);
             }
             else
                 throw new CommonException($"Missing input path: {Cfg.InputPath}");
@@ -46,6 +45,7 @@ namespace OfflineAudioProcessingSystem.AudioTransfer
 
     class AudioFolderTransfer : FolderTransfer
     {
+        const int BUFFER_SIZE = 50 * 1024;  // 50K.
         HashSet<string> ValidExtSet = new HashSet<string>();
         public int SampleRate { get; set; } = 16000;
         public int NumChannels { get; set; } = 1;
@@ -75,7 +75,7 @@ namespace OfflineAudioProcessingSystem.AudioTransfer
         {
             string ext = inputPath.Split('.').Last().ToLower();
             Sanity.Requires(ValidExtSet.Contains(ext), $"Invalid extension: {ext}");
-            LocalCommon.SetAudio(inputPath.WrapPath(), SampleRate, NumChannels, outputPath.WrapPath());
+            ConvertToWave(inputPath, outputPath);
             Wave w = new Wave();
             w.ShallowParse(outputPath);
             string reportLine = $"{inputPath.Split('\\').Last()}\t{outputPath.Split('\\').Last()}\t{w.AudioLength}";
@@ -101,44 +101,49 @@ namespace OfflineAudioProcessingSystem.AudioTransfer
             }
         }
 
-        private bool AudioCompare(string waveFile1, string waveFile2)
+        public void ConvertToWave(string inputPath, string outputPath)
+        {
+            LocalCommon.SetAudioWithFfmpeg(inputPath.WrapPath(), SampleRate, NumChannels, outputPath.WrapPath());
+            if (!File.Exists(outputPath))
+                LocalCommon.SetAudioWithSox(inputPath.WrapPath(), SampleRate, NumChannels, outputPath.WrapPath());
+        }
+
+        public bool AudioCompare(string waveFilePath1, string waveFilePath2)
         {
             Wave w1 = new Wave();
-            w1.ShallowParse(waveFile1);            
+            w1.ShallowParse(waveFilePath1);
             Wave w2 = new Wave();
-            w2.ShallowParse(waveFile2);
-
-            if (w1.DataChunk.Length != w2.DataChunk.Length)
-                return false;
-            using(FileStream fs1=new FileStream(waveFile1,FileMode.Open,FileAccess.Read))
-            using(FileStream fs2=new FileStream(waveFile2, FileMode.Open, FileAccess.Read))
+            w2.ShallowParse(waveFilePath1);
+            using(FileStream fs1=new FileStream(waveFilePath1,FileMode.Open,FileAccess.Read))
+            using(FileStream fs2=new FileStream(waveFilePath2, FileMode.Open, FileAccess.Read))
             {
                 fs1.Seek(w1.DataChunk.Offset + 8, SeekOrigin.Begin);
                 fs2.Seek(w2.DataChunk.Offset + 8, SeekOrigin.Begin);
+                byte[] buffer1 = new byte[BUFFER_SIZE];
+                byte[] buffer2 = new byte[BUFFER_SIZE];
                 while (fs1.Position < fs1.Length)
                 {
+                    int count = Math.Min(BUFFER_SIZE, (int)(fs1.Length - fs1.Position));
                     try
                     {
-                        if (fs1.ReadByte() == fs2.ReadByte())
+                        fs1.Read(buffer1, 0, BUFFER_SIZE);
+                        fs2.Read(buffer2, 0, BUFFER_SIZE);
+                        if (buffer1.SequenceEqual(buffer2))
                             continue;
-                        else
-                            return false;
+                        return false;
                     }
                     catch
                     {
                         return false;
                     }
                 }
+                return true;
             }
-            return true;
         }
-
         public override string ItemRename(string inputItemName)
         {
-            Sanity.Requires(inputItemName.Contains('.'), $"No extension: {inputItemName}");
-            int i = inputItemName.LastIndexOf('.');
-            string prefix = inputItemName.Substring(0, i);
-            return $"{prefix}.wav";
+            FileInfo file = new FileInfo(inputItemName);
+            return file.Name.Replace(file.Extension, "wav");
         }
 
         protected override void PostRun()

--- a/OfflineAudioProcessingSystem/Internal/Data/AudioInputExt.txt
+++ b/OfflineAudioProcessingSystem/Internal/Data/AudioInputExt.txt
@@ -3,3 +3,4 @@ ogg
 mp3
 mp4
 m4a
+aif

--- a/OfflineAudioProcessingSystem/Test.cs
+++ b/OfflineAudioProcessingSystem/Test.cs
@@ -12,9 +12,12 @@ namespace OfflineAudioProcessingSystem
     {
         public Test(string[] args)
         {
-            string w1 = @"D:\WorkFolder\Input\300hrsRecordingContent\Zurich\Zürich 14.12.2020\Zürich+38+FEMALE+27.wav";
-            string w2 = @"D:\WorkFolder\Input\300hrsRecordingContent\Zurich\Zürich 13.12.2020 F\Zürich+16+FEMALE+27.wav";
-            var b=CompareWaves(w1, w2);
+            //string w1 = @"D:\WorkFolder\Input\300hrsRecordingContent\Zurich\Zürich 14.12.2020\Zürich+38+FEMALE+27.wav";
+            //string w2 = @"D:\WorkFolder\Input\300hrsRecordingContent\Zurich\Zürich 13.12.2020 F\Zürich+16+FEMALE+27.wav";
+            //AudioTransfer.AudioFolderTransfer aft = new AudioTransfer.AudioFolderTransfer("", "", "");
+            //var r = aft.AudioCompareBlock(w1, w2);            
+            //Wave w = new Wave();
+            //w.ShallowParse(@"D:\Tmp\Basel 12.12.2020 Valentin\Basel+Va001+Male+.wav");
         }
 
         private void GenerateRecords()


### PR DESCRIPTION
Process with buffer size instead of read bytes, in order to  speed up.
Transfer with Sox and Ffmpeg together.